### PR TITLE
fix: Add optional kind kubelet override

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,9 @@ on:
     branches: [main]
 
 env:
-  HARBOR_USERNAME: ${{ vars.HARBOR_USERNAME }}
+  REGISTRY_ADDRESS: ${{ vars.REGISTRY_ADDRESS || '8gears.container-registry.com' }}
+  PROJECT_NAME: ${{ vars.PROJECT_NAME || '8gcr' }}
+  REGISTRY_USERNAME: ${{ vars.REGISTRY_USERNAME }}
 
 jobs:
   ci:
@@ -52,9 +54,9 @@ jobs:
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'
         uses: docker/login-action@v3
         with:
-          registry: registry.goharbor.io
-          username: ${{ env.HARBOR_USERNAME }}
-          password: ${{ secrets.HARBOR_PASSWORD }}
+          registry: ${{ env.REGISTRY_ADDRESS }}
+          username: ${{ env.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
 
       - name: Build and push image
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,9 @@ on:
     types: [published]
 
 env:
-  HARBOR_USERNAME: ${{ vars.HARBOR_USERNAME }}
+  REGISTRY_ADDRESS: ${{ vars.REGISTRY_ADDRESS || '8gears.container-registry.com' }}
+  PROJECT_NAME: ${{ vars.PROJECT_NAME || '8gcr' }}
+  REGISTRY_USERNAME: ${{ vars.REGISTRY_USERNAME }}
 
 jobs:
   release:
@@ -25,6 +27,9 @@ jobs:
         with:
           version: 3.x
 
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
       - name: Build all platforms
         run: task build-all
 
@@ -34,6 +39,8 @@ jobs:
           files: |
             bin/credential-provider-harbor-linux-amd64
             bin/credential-provider-harbor-linux-arm64
+            bin/credential-provider-harbor-installer-linux-amd64
+            bin/credential-provider-harbor-installer-linux-arm64
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -41,9 +48,15 @@ jobs:
       - name: Login to Harbor Registry
         uses: docker/login-action@v3
         with:
-          registry: registry.goharbor.io
-          username: ${{ env.HARBOR_USERNAME }}
-          password: ${{ secrets.HARBOR_PASSWORD }}
+          registry: ${{ env.REGISTRY_ADDRESS }}
+          username: ${{ env.REGISTRY_USERNAME }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: Login to Harbor Helm registry
+        env:
+          REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
+        run: |
+          printf '%s' "$REGISTRY_PASSWORD" | helm registry login "$REGISTRY_ADDRESS" --username "$REGISTRY_USERNAME" --password-stdin
 
       - name: Build and push release image
         if: ${{ !github.event.release.prerelease }}
@@ -52,3 +65,6 @@ jobs:
       - name: Build and push prerelease image
         if: ${{ github.event.release.prerelease }}
         run: task docker-push-version
+
+      - name: Package and push Helm chart
+        run: task helm-push

--- a/README.md
+++ b/README.md
@@ -546,6 +546,8 @@ options:
 
 See example files in [`examples/kubernetes/`](examples/kubernetes/).
 
+For kind clusters, also verify kubelet is started with the credential provider flags. If the live kubelet command line is missing `--image-credential-provider-bin-dir` and `--image-credential-provider-config` after install, enable the optional Helm setting `kubelet.forceExecStartOverride=true`. It resets kind kubelet `ExecStart` and appends the provider flags directly; leave it disabled unless `KUBELET_EXTRA_ARGS` is not reflected in the live process.
+
 #### k8s_credential_provider_config.yaml
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -33,12 +33,42 @@ The kubelet calls this binary via stdin/stdout protocol: it receives a `Credenti
 
 The recommended install path is the Helm chart. It runs a privileged DaemonSet on every node, copies the credential provider binary onto the host, writes or merges the kubelet credential provider config, creates the node audience RBAC, configures kubelet where the selected profile supports it, and restarts kubelet by default.
 
+Set these values first:
+
+```bash
+export REGISTRY_ADDRESS=8gears.container-registry.com
+export PROJECT_NAME=8gcr
+export INSTALLER_IMAGE="${REGISTRY_ADDRESS}/${PROJECT_NAME}/credential-provider-harbor-deployer"
+
+# Harbor registry that workloads pull from.
+export HARBOR_REGISTRY=harbor.example.com
+
+# Audience Harbor expects in service account tokens. Use the exact value configured in Harbor FedIDP.
+export HARBOR_AUDIENCE=https://harbor.example.com
+```
+
+Install from a local checkout:
+
 ```bash
 helm upgrade --install credential-provider-harbor \
   deploy/helm/credential-provider-harbor/ \
   --namespace kube-system \
   --create-namespace \
-  --set registry.host=<your-registry-domain>
+  --set image.repository="${INSTALLER_IMAGE}" \
+  --set registry.host="${HARBOR_REGISTRY}" \
+  --set registry.audience="${HARBOR_AUDIENCE}"
+```
+
+Install a released OCI chart:
+
+```bash
+helm upgrade --install credential-provider-harbor \
+  "oci://${REGISTRY_ADDRESS}/${PROJECT_NAME}/credential-provider-harbor" \
+  --namespace kube-system \
+  --create-namespace \
+  --set image.repository="${INSTALLER_IMAGE}" \
+  --set registry.host="${HARBOR_REGISTRY}" \
+  --set registry.audience="${HARBOR_AUDIENCE}"
 ```
 
 Select a platform profile when the default generic kubelet paths are not right for your cluster:
@@ -55,25 +85,87 @@ Select a platform profile when the default generic kubelet paths are not right f
 Examples:
 
 ```bash
+# Generic kubeadm/systemd nodes.
+helm upgrade --install credential-provider-harbor \
+  deploy/helm/credential-provider-harbor/ \
+  --namespace kube-system \
+  --create-namespace \
+  --set profile=generic \
+  --set image.repository="${INSTALLER_IMAGE}" \
+  --set registry.host="${HARBOR_REGISTRY}" \
+  --set registry.audience="${HARBOR_AUDIENCE}"
+
 # EKS AL2023. Preserves the existing ECR credential provider entry.
 helm upgrade --install credential-provider-harbor \
   deploy/helm/credential-provider-harbor/ \
   --namespace kube-system \
+  --create-namespace \
   --set profile=eks \
-  --set registry.host=<your-registry-domain>
+  --set image.repository="${INSTALLER_IMAGE}" \
+  --set registry.host="${HARBOR_REGISTRY}" \
+  --set registry.audience="${HARBOR_AUDIENCE}"
 
 # k3s/k3d.
 helm upgrade --install credential-provider-harbor \
   deploy/helm/credential-provider-harbor/ \
   --namespace kube-system \
+  --create-namespace \
   --set profile=k3s \
-  --set registry.host=<your-registry-domain>
+  --set image.repository="${INSTALLER_IMAGE}" \
+  --set registry.host="${HARBOR_REGISTRY}" \
+  --set registry.audience="${HARBOR_AUDIENCE}"
+
+# kind.
+helm upgrade --install credential-provider-harbor \
+  deploy/helm/credential-provider-harbor/ \
+  --namespace kube-system \
+  --create-namespace \
+  --set profile=kind \
+  --set image.repository="${INSTALLER_IMAGE}" \
+  --set registry.host="${HARBOR_REGISTRY}" \
+  --set registry.audience="${HARBOR_AUDIENCE}"
+
+# kind fallback. Enable only if the live kubelet command line is missing the provider flags.
+helm upgrade --install credential-provider-harbor \
+  deploy/helm/credential-provider-harbor/ \
+  --namespace kube-system \
+  --create-namespace \
+  --set profile=kind \
+  --set kubelet.forceExecStartOverride=true \
+  --set image.repository="${INSTALLER_IMAGE}" \
+  --set registry.host="${HARBOR_REGISTRY}" \
+  --set registry.audience="${HARBOR_AUDIENCE}"
+
+# GKE Standard best effort. GKE Autopilot is unsupported.
+helm upgrade --install credential-provider-harbor \
+  deploy/helm/credential-provider-harbor/ \
+  --namespace kube-system \
+  --create-namespace \
+  --set profile=gke \
+  --set image.repository="${INSTALLER_IMAGE}" \
+  --set registry.host="${HARBOR_REGISTRY}" \
+  --set registry.audience="${HARBOR_AUDIENCE}"
+
+# Custom host paths.
+helm upgrade --install credential-provider-harbor \
+  deploy/helm/credential-provider-harbor/ \
+  --namespace kube-system \
+  --create-namespace \
+  --set profile=custom \
+  --set credentialProvider.binDir=/opt/kubelet/credential-providers \
+  --set credentialProvider.configPath=/etc/kubernetes/credential-providers/config.yaml \
+  --set image.repository="${INSTALLER_IMAGE}" \
+  --set registry.host="${HARBOR_REGISTRY}" \
+  --set registry.audience="${HARBOR_AUDIENCE}"
 
 # Install files but do not restart kubelet.
 helm upgrade --install credential-provider-harbor \
   deploy/helm/credential-provider-harbor/ \
   --namespace kube-system \
-  --set registry.host=<your-registry-domain> \
+  --create-namespace \
+  --set image.repository="${INSTALLER_IMAGE}" \
+  --set registry.host="${HARBOR_REGISTRY}" \
+  --set registry.audience="${HARBOR_AUDIENCE}" \
   --set kubelet.restart=false
 ```
 
@@ -139,12 +231,42 @@ task build-all
 # Build Docker image
 task docker-build
 
+# Push Docker image to REGISTRY_ADDRESS/PROJECT_NAME
+REGISTRY_ADDRESS=8gears.container-registry.com PROJECT_NAME=8gcr task docker-push
+
+# Package and push the Helm chart to OCI
+REGISTRY_ADDRESS=8gears.container-registry.com PROJECT_NAME=8gcr task helm-push
+
 # Run tests
 task test
 
 # Run linter
 task lint
 ```
+
+### Release Configuration
+
+GitHub Actions publishes images and Helm charts to `REGISTRY_ADDRESS/PROJECT_NAME`. For example, with `REGISTRY_ADDRESS=8gears.container-registry.com` and `PROJECT_NAME=8gcr`, the deployer image is pushed to:
+
+```text
+8gears.container-registry.com/8gcr/credential-provider-harbor-deployer
+```
+
+Set these repository variables:
+
+```text
+REGISTRY_ADDRESS=8gears.container-registry.com
+PROJECT_NAME=8gcr
+REGISTRY_USERNAME=<robot-or-user-with-push-access>
+```
+
+Set this repository secret:
+
+```text
+REGISTRY_PASSWORD=<password-or-token>
+```
+
+The release workflow uploads Linux credential-provider and installer binaries to the GitHub release, pushes the multi-arch deployer image, and pushes the Helm chart as OCI to `oci://${REGISTRY_ADDRESS}/${PROJECT_NAME}/credential-provider-harbor`.
 
 ---
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -6,8 +6,19 @@ vars:
   MODULE: github.com/container-registry/harbor-workload-identity-federation
   VERSION:
     sh: git describe --tags --always --dirty 2>/dev/null || echo "dev"
-  REGISTRY: registry.goharbor.io/harbor-workload-identity-federation
+  CHART_VERSION:
+    sh: |
+      tag=$(git describe --tags --exact-match 2>/dev/null || true)
+      if [ -n "$tag" ]; then
+        printf '%s' "${tag#v}"
+      else
+        awk '/^version:/ {print $2}' deploy/helm/credential-provider-harbor/Chart.yaml
+      fi
+  REGISTRY_ADDRESS: '{{default "8gears.container-registry.com" .REGISTRY_ADDRESS}}'
+  PROJECT_NAME: '{{default "8gcr" .PROJECT_NAME}}'
+  REGISTRY: '{{.REGISTRY_ADDRESS}}/{{.PROJECT_NAME}}'
   IMAGE_NAME: credential-provider-harbor-deployer
+  CHART: credential-provider-harbor
 
 tasks:
   default:
@@ -85,6 +96,21 @@ tasks:
           -t {{.REGISTRY}}/{{.IMAGE_NAME}}:{{.VERSION}}
           -t {{.REGISTRY}}/{{.IMAGE_NAME}}:latest
           --push .
+
+  helm-package:
+    desc: Package the Helm chart
+    cmds:
+      - mkdir -p dist
+      - helm package deploy/helm/{{.CHART}}/
+          --destination dist
+          --version {{.CHART_VERSION}}
+          --app-version {{.VERSION}}
+
+  helm-push:
+    desc: Package and push the Helm chart as OCI
+    deps: [helm-package]
+    cmds:
+      - helm push dist/{{.CHART}}-{{.CHART_VERSION}}.tgz oci://{{.REGISTRY}}
 
   helm-lint:
     desc: Lint the Helm chart

--- a/cmd/credential-provider-harbor-installer/main.go
+++ b/cmd/credential-provider-harbor-installer/main.go
@@ -23,26 +23,27 @@ const (
 )
 
 type options struct {
-	Profile             string
-	HostRoot            string
-	SourceBinary        string
-	BinaryName          string
-	BinDir              string
-	ConfigPath          string
-	ConfigFormat        string
-	RegistryHost        string
-	RegistryAudience    string
-	RegistryUsername    string
-	MatchImages         []string
-	CacheDuration       string
-	ConfigureKubelet    bool
-	RestartKubelet      bool
-	KubeletService      string
-	SystemdDropInPath   string
-	K3sConfigDropInPath string
-	PreserveECRProvider bool
-	SleepForever        bool
-	InstalledMarker     string
+	Profile               string
+	HostRoot              string
+	SourceBinary          string
+	BinaryName            string
+	BinDir                string
+	ConfigPath            string
+	ConfigFormat          string
+	RegistryHost          string
+	RegistryAudience      string
+	RegistryUsername      string
+	MatchImages           []string
+	CacheDuration         string
+	ConfigureKubelet      bool
+	RestartKubelet        bool
+	ForceKubeletExecStart bool
+	KubeletService        string
+	SystemdDropInPath     string
+	K3sConfigDropInPath   string
+	PreserveECRProvider   bool
+	SleepForever          bool
+	InstalledMarker       string
 }
 
 type profileDefaults struct {
@@ -151,26 +152,27 @@ func optionsFromEnv() (options, error) {
 	}
 
 	return options{
-		Profile:             profile,
-		HostRoot:            env("HOST_ROOT", "/host"),
-		SourceBinary:        env("SOURCE_BINARY", "/usr/local/bin/credential-provider-harbor"),
-		BinaryName:          env("BINARY_NAME", providerName),
-		BinDir:              binDir,
-		ConfigPath:          configPath,
-		ConfigFormat:        configFormat,
-		RegistryHost:        registryHost,
-		RegistryAudience:    env("REGISTRY_AUDIENCE", registryHost),
-		RegistryUsername:    env("REGISTRY_USERNAME", "jwt"),
-		MatchImages:         listValue(env("MATCH_IMAGES", registryHost)),
-		CacheDuration:       env("CACHE_DURATION", "1h"),
-		ConfigureKubelet:    boolEnv("CONFIGURE_KUBELET", true),
-		RestartKubelet:      boolEnv("RESTART_KUBELET", true),
-		KubeletService:      env("KUBELET_SERVICE", defaults.KubeletService),
-		SystemdDropInPath:   env("SYSTEMD_DROP_IN_PATH", defaults.SystemdDropInPath),
-		K3sConfigDropInPath: env("K3S_CONFIG_DROP_IN_PATH", defaults.K3sConfigDropInPath),
-		PreserveECRProvider: preserveECR,
-		SleepForever:        boolEnv("SLEEP_FOREVER", false),
-		InstalledMarker:     env("INSTALLED_MARKER", "/var/run/credential-provider-harbor-installed"),
+		Profile:               profile,
+		HostRoot:              env("HOST_ROOT", "/host"),
+		SourceBinary:          env("SOURCE_BINARY", "/usr/local/bin/credential-provider-harbor"),
+		BinaryName:            env("BINARY_NAME", providerName),
+		BinDir:                binDir,
+		ConfigPath:            configPath,
+		ConfigFormat:          configFormat,
+		RegistryHost:          registryHost,
+		RegistryAudience:      env("REGISTRY_AUDIENCE", registryHost),
+		RegistryUsername:      env("REGISTRY_USERNAME", "jwt"),
+		MatchImages:           listValue(env("MATCH_IMAGES", registryHost)),
+		CacheDuration:         env("CACHE_DURATION", "1h"),
+		ConfigureKubelet:      boolEnv("CONFIGURE_KUBELET", true),
+		RestartKubelet:        boolEnv("RESTART_KUBELET", true),
+		ForceKubeletExecStart: boolEnv("FORCE_KUBELET_EXECSTART", false),
+		KubeletService:        env("KUBELET_SERVICE", defaults.KubeletService),
+		SystemdDropInPath:     env("SYSTEMD_DROP_IN_PATH", defaults.SystemdDropInPath),
+		K3sConfigDropInPath:   env("K3S_CONFIG_DROP_IN_PATH", defaults.K3sConfigDropInPath),
+		PreserveECRProvider:   preserveECR,
+		SleepForever:          boolEnv("SLEEP_FOREVER", false),
+		InstalledMarker:       env("INSTALLED_MARKER", "/var/run/credential-provider-harbor-installed"),
 	}, nil
 }
 
@@ -375,6 +377,11 @@ func configureKubelet(opts options) (bool, error) {
 		return false, nil
 	case "k3s", "k3d":
 		return configureK3s(opts)
+	case "kind":
+		if !opts.ForceKubeletExecStart {
+			return configureSystemdKubelet(opts)
+		}
+		return configureKindSystemdKubelet(opts)
 	default:
 		return configureSystemdKubelet(opts)
 	}
@@ -406,6 +413,38 @@ Environment="KUBELET_EXTRA_ARGS=--image-credential-provider-bin-dir=%s --image-c
 		fmt.Printf("[INFO] Wrote kubelet systemd drop-in: %s\n", hostDropInPath)
 	} else {
 		fmt.Printf("[INFO] Kubelet systemd drop-in already up to date: %s\n", hostDropInPath)
+	}
+	return changed, nil
+}
+
+func configureKindSystemdKubelet(opts options) (bool, error) {
+	service := opts.KubeletService
+	if service == "" {
+		service = "kubelet"
+	}
+	dropInPath := opts.SystemdDropInPath
+	if dropInPath == "" {
+		dropInPath = filepath.Join("/etc/systemd/system", service+".service.d", "99-credential-provider-harbor.conf")
+	}
+
+	content := fmt.Sprintf(`[Service]
+Environment="KUBELET_EXTRA_ARGS=--image-credential-provider-bin-dir=%s --image-credential-provider-config=%s"
+ExecStart=
+ExecStart=/usr/bin/kubelet $KUBELET_KUBECONFIG_ARGS $KUBELET_CONFIG_ARGS $KUBELET_KUBEADM_ARGS --image-credential-provider-bin-dir=%s --image-credential-provider-config=%s
+`, opts.BinDir, opts.ConfigPath, opts.BinDir, opts.ConfigPath)
+
+	hostDropInPath := hostPath(opts, dropInPath)
+	if err := os.MkdirAll(filepath.Dir(hostDropInPath), 0755); err != nil {
+		return false, fmt.Errorf("create kubelet systemd drop-in directory: %w", err)
+	}
+	changed, err := writeFileIfChanged(hostDropInPath, []byte(content), 0644, true)
+	if err != nil {
+		return false, fmt.Errorf("write kind kubelet systemd drop-in: %w", err)
+	}
+	if changed {
+		fmt.Printf("[INFO] Wrote kind kubelet systemd drop-in: %s\n", hostDropInPath)
+	} else {
+		fmt.Printf("[INFO] Kind kubelet systemd drop-in already up to date: %s\n", hostDropInPath)
 	}
 	return changed, nil
 }

--- a/cmd/credential-provider-harbor-installer/main_test.go
+++ b/cmd/credential-provider-harbor-installer/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -37,6 +38,80 @@ func TestMergeProviderReplacesExistingProviderAndPreservesOthers(t *testing.T) {
 	}
 	if merged.Providers[1].Name != "ecr-credential-provider" {
 		t.Fatalf("Providers[1].Name = %q, want ecr-credential-provider", merged.Providers[1].Name)
+	}
+}
+
+func TestConfigureKindSystemdKubeletWritesExecStartOverride(t *testing.T) {
+	tmpDir := t.TempDir()
+	opts := options{
+		HostRoot:       tmpDir,
+		BinDir:         "/var/lib/kubelet/credential-provider",
+		ConfigPath:     "/var/lib/kubelet/credential-provider-config.yaml",
+		KubeletService: "kubelet",
+	}
+
+	changed, err := configureKindSystemdKubelet(opts)
+	if err != nil {
+		t.Fatalf("configureKindSystemdKubelet() error: %v", err)
+	}
+	if !changed {
+		t.Fatal("configureKindSystemdKubelet() changed = false, want true")
+	}
+	changed, err = configureKindSystemdKubelet(opts)
+	if err != nil {
+		t.Fatalf("second configureKindSystemdKubelet() error: %v", err)
+	}
+	if changed {
+		t.Fatal("second configureKindSystemdKubelet() changed = true, want false")
+	}
+
+	dropIn := filepath.Join(tmpDir, "etc/systemd/system/kubelet.service.d/99-credential-provider-harbor.conf")
+	data, err := os.ReadFile(dropIn)
+	if err != nil {
+		t.Fatalf("read drop-in: %v", err)
+	}
+	for _, want := range [][]byte{
+		[]byte("ExecStart="),
+		[]byte("ExecStart=/usr/bin/kubelet $KUBELET_KUBECONFIG_ARGS $KUBELET_CONFIG_ARGS $KUBELET_KUBEADM_ARGS"),
+		[]byte("--image-credential-provider-bin-dir=/var/lib/kubelet/credential-provider"),
+		[]byte("--image-credential-provider-config=/var/lib/kubelet/credential-provider-config.yaml"),
+	} {
+		if !bytes.Contains(data, want) {
+			t.Fatalf("drop-in missing %q:\n%s", want, data)
+		}
+	}
+}
+
+func TestConfigureKubeletKindDefaultsToExtraArgsDropIn(t *testing.T) {
+	tmpDir := t.TempDir()
+	opts := options{
+		Profile:               "kind",
+		HostRoot:              tmpDir,
+		BinDir:                "/var/lib/kubelet/credential-provider",
+		ConfigPath:            "/var/lib/kubelet/credential-provider-config.yaml",
+		ConfigureKubelet:      true,
+		KubeletService:        "kubelet",
+		ForceKubeletExecStart: false,
+	}
+
+	changed, err := configureKubelet(opts)
+	if err != nil {
+		t.Fatalf("configureKubelet() error: %v", err)
+	}
+	if !changed {
+		t.Fatal("configureKubelet() changed = false, want true")
+	}
+
+	dropIn := filepath.Join(tmpDir, "etc/systemd/system/kubelet.service.d/99-credential-provider-harbor.conf")
+	data, err := os.ReadFile(dropIn)
+	if err != nil {
+		t.Fatalf("read drop-in: %v", err)
+	}
+	if bytes.Contains(data, []byte("ExecStart=")) {
+		t.Fatalf("default kind drop-in contains ExecStart override:\n%s", data)
+	}
+	if !bytes.Contains(data, []byte("KUBELET_EXTRA_ARGS=")) {
+		t.Fatalf("default kind drop-in missing KUBELET_EXTRA_ARGS:\n%s", data)
 	}
 }
 
@@ -104,6 +179,9 @@ func TestOptionsDefaultToNodeModificationAndRestart(t *testing.T) {
 	}
 	if !opts.RestartKubelet {
 		t.Fatal("RestartKubelet = false, want true")
+	}
+	if opts.ForceKubeletExecStart {
+		t.Fatal("ForceKubeletExecStart = true, want false")
 	}
 }
 

--- a/deploy/helm/credential-provider-harbor/README.md
+++ b/deploy/helm/credential-provider-harbor/README.md
@@ -30,6 +30,8 @@ By default the chart configures kubelet and restarts it after installing the bin
 
 GKE Autopilot is unsupported because it blocks privileged host access.
 
+For `profile=kind`, verify the live kubelet command line inside the kind node includes `--image-credential-provider-bin-dir` and `--image-credential-provider-config`. If image pulls fail with `no basic auth credentials` and those flags are missing, retry with `--set kubelet.forceExecStartOverride=true`. This resets kind kubelet `ExecStart` and appends the provider flags directly; leave it disabled unless kind does not propagate `KUBELET_EXTRA_ARGS`.
+
 ## Required Harbor Setup
 
 Configure Harbor FedIDP with the cluster issuer and JWKS, then create a federated robot account matching the service account token claims, typically `aud`, `iss`, and `sub`.

--- a/deploy/helm/credential-provider-harbor/README.md
+++ b/deploy/helm/credential-provider-harbor/README.md
@@ -11,6 +11,8 @@ helm upgrade --install credential-provider-harbor . \
   --set registry.host=harbor.example.com
 ```
 
+The published deployer image defaults to `8gears.container-registry.com/8gcr/credential-provider-harbor-deployer`. If you publish the image to a different registry project, set `image.repository=<registry>/<project>/credential-provider-harbor-deployer`.
+
 By default the chart configures kubelet and restarts it after installing the binary and config. Disable that behavior only when you want to roll nodes yourself:
 
 ```bash

--- a/deploy/helm/credential-provider-harbor/templates/daemonset.yaml
+++ b/deploy/helm/credential-provider-harbor/templates/daemonset.yaml
@@ -65,6 +65,8 @@ spec:
           value: {{ .Values.kubelet.serviceName | quote }}
         - name: SYSTEMD_DROP_IN_PATH
           value: {{ .Values.kubelet.systemdDropInPath | quote }}
+        - name: FORCE_KUBELET_EXECSTART
+          value: {{ .Values.kubelet.forceExecStartOverride | quote }}
         - name: K3S_CONFIG_DROP_IN_PATH
           value: {{ .Values.kubelet.k3sConfigDropInPath | quote }}
         {{- with .Values.extraEnv }}

--- a/deploy/helm/credential-provider-harbor/values.yaml
+++ b/deploy/helm/credential-provider-harbor/values.yaml
@@ -64,6 +64,9 @@ kubelet:
   serviceName: ""
   # -- Override systemd drop-in path for generic/kind/gke/custom profiles.
   systemdDropInPath: ""
+  # -- For kind only: force a kubelet ExecStart override instead of only setting KUBELET_EXTRA_ARGS.
+  # Enable this if the live kubelet command line does not include the credential-provider flags after install.
+  forceExecStartOverride: false
   # -- Override k3s config drop-in path for k3s/k3d profiles.
   k3sConfigDropInPath: ""
 

--- a/deploy/helm/credential-provider-harbor/values.yaml
+++ b/deploy/helm/credential-provider-harbor/values.yaml
@@ -3,7 +3,7 @@
 # -- Deployer image containing the credential-provider-harbor binary
 image:
   # -- Container registry and repository
-  repository: registry.goharbor.io/harbor-workload-identity-federation/credential-provider-harbor-deployer
+  repository: 8gears.container-registry.com/8gcr/credential-provider-harbor-deployer
   # -- Image tag (defaults to Chart.appVersion)
   tag: ""
   # -- Image pull policy

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,36 @@
+# Examples
+
+This directory contains copy-paste starting points for Harbor Workload Identity Federation.
+
+## Available Examples
+
+| Directory | Purpose |
+|-----------|---------|
+| [`github-actions`](github-actions/) | Push and pull images from GitHub Actions using GitHub OIDC tokens. |
+| [`gitlab-ci`](gitlab-ci/) | Push images from GitLab CI using GitLab `id_tokens`. |
+| [`kubernetes`](kubernetes/) | Install and test the kubelet credential provider for secretless Kubernetes image pulls. |
+
+## Before You Start
+
+Create a Harbor Federated IDP for the workload issuer, then create a federated robot account with pull or push permissions for the target project.
+
+Use the same audience value in both places:
+
+```text
+Harbor Federated IDP audience == token request audience
+```
+
+For registry publishing in this repository's CI/release workflows, set these GitHub repository variables and secret:
+
+```text
+REGISTRY_ADDRESS=8gears.container-registry.com
+PROJECT_NAME=8gcr
+REGISTRY_USERNAME=<robot-or-user-with-push-access>
+REGISTRY_PASSWORD=<secret>
+```
+
+The resulting image path is:
+
+```text
+8gears.container-registry.com/8gcr/credential-provider-harbor-deployer
+```

--- a/examples/github-actions/README.md
+++ b/examples/github-actions/README.md
@@ -1,0 +1,57 @@
+# GitHub Actions Example
+
+This example uses GitHub Actions OIDC to authenticate to Harbor without storing a registry password in GitHub secrets.
+
+## Harbor Setup
+
+Create a Harbor Federated IDP:
+
+```text
+OpenID configuration URL: https://token.actions.githubusercontent.com/.well-known/openid-configuration
+Issuer: https://token.actions.githubusercontent.com
+Audience: <your-registry-domain-or-url>
+```
+
+Create a federated robot account with claim rules matching your workflow, for example:
+
+```text
+iss == https://token.actions.githubusercontent.com
+aud == <your-registry-domain-or-url>
+repository == <owner>/<repo>
+```
+
+Grant the robot account push or pull permission on the target Harbor project.
+
+## Use The Example
+
+Copy [`example_1.yml`](example_1.yml) to your repository:
+
+```bash
+mkdir -p .github/workflows
+cp examples/github-actions/example_1.yml .github/workflows/harbor-wif.yml
+```
+
+Replace these values in the workflow:
+
+```text
+silly-snyder.container-registry.com -> <your-registry-domain>
+library/image -> <your-project>/<your-image>
+```
+
+The workflow must request an OIDC token:
+
+```yaml
+permissions:
+  id-token: write
+  contents: read
+```
+
+The token request audience must exactly match the Harbor Federated IDP audience:
+
+```bash
+"${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=<your-registry-domain-or-url>"
+```
+
+## Notes
+
+The example prints only decoded JWT header and payload for debugging. Do not print the raw token in real pipelines.

--- a/examples/gitlab-ci/README.md
+++ b/examples/gitlab-ci/README.md
@@ -1,0 +1,58 @@
+# GitLab CI Example
+
+This example uses GitLab CI OIDC `id_tokens` to authenticate to Harbor without storing a registry password in GitLab variables.
+
+## Harbor Setup
+
+Create a Harbor Federated IDP for your GitLab instance. For GitLab.com:
+
+```text
+OpenID configuration URL: https://gitlab.com/.well-known/openid-configuration
+Issuer: https://gitlab.com
+Audience: <your-registry-domain-or-url>
+```
+
+Create a federated robot account with claim rules matching your project, for example:
+
+```text
+iss == https://gitlab.com
+aud == <your-registry-domain-or-url>
+project_path == <group>/<project>
+```
+
+Grant the robot account push or pull permission on the target Harbor project.
+
+## Use The Example
+
+Copy [`.gitlab-ci.yml`](.gitlab-ci.yml) into your GitLab repository or merge the job into your existing pipeline.
+
+Replace these values:
+
+```text
+macfly4200.8gears.ch -> <your-registry-domain>
+library/image -> <your-project>/<your-image>
+```
+
+The `id_tokens` audience must exactly match the Harbor Federated IDP audience:
+
+```yaml
+id_tokens:
+  ID_TOKEN:
+    aud: <your-registry-domain-or-url>
+```
+
+The example writes Docker auth as `not-relevant:<OIDC-token>`. Harbor validates the token through the configured Federated IDP and maps it to the federated robot account.
+
+## BuildKit
+
+The sample uses a remote BuildKit endpoint:
+
+```yaml
+BUILDKIT_HOST: tcp://buildkitd:1234
+```
+
+If you do not run a remote BuildKit service, replace the build step with your own Docker or BuildKit setup.
+
+## Notes
+
+The example prints only decoded JWT header and payload for debugging. Do not print the raw token in real pipelines.

--- a/examples/kubernetes/README.md
+++ b/examples/kubernetes/README.md
@@ -1,0 +1,54 @@
+# Kubernetes Examples
+
+These examples show the resources kubelet needs to pull Harbor images with `credential-provider-harbor` and service account tokens.
+
+## kind
+
+For local kind clusters, make sure the kubelet process is actually started with the credential provider flags. Installing the binary and `CredentialProviderConfig` file is not enough.
+
+Use the Helm chart with the kind profile:
+
+```bash
+helm upgrade --install credential-provider-harbor deploy/helm/credential-provider-harbor \
+  --namespace kube-system \
+  --create-namespace \
+  --set profile=kind \
+  --set registry.host=harbor.example.com \
+  --set registry.audience=https://harbor.example.com
+```
+
+Verify the live kubelet command line inside the kind node includes both flags:
+
+```bash
+docker exec <kind-node> sh -c 'tr "\0" " " < /proc/$(pidof kubelet)/cmdline; printf "\n"'
+```
+
+Expected flags:
+
+```text
+--image-credential-provider-bin-dir=/var/lib/kubelet/credential-provider
+--image-credential-provider-config=/var/lib/kubelet/credential-provider-config.yaml
+```
+
+If those flags are missing after install and restart, enable the kind-only forced `ExecStart` override:
+
+```bash
+helm upgrade --install credential-provider-harbor deploy/helm/credential-provider-harbor \
+  --namespace kube-system \
+  --create-namespace \
+  --set profile=kind \
+  --set registry.host=harbor.example.com \
+  --set registry.audience=https://harbor.example.com \
+  --set kubelet.forceExecStartOverride=true
+```
+
+This writes a drop-in equivalent to [`kind-kubelet-systemd-dropin.conf`](kind-kubelet-systemd-dropin.conf). It resets kubelet `ExecStart` and appends the credential-provider flags directly. Use it only when kind does not propagate `KUBELET_EXTRA_ARGS` into the live kubelet process.
+
+Then apply the audience RBAC and deploy a pod without `imagePullSecrets`:
+
+```bash
+kubectl apply -f examples/kubernetes/rbac-audience.yaml
+kubectl apply -f examples/kubernetes/pod-example.yaml
+```
+
+If the pod fails with `no basic auth credentials`, check the live kubelet command line first. That error usually means kubelet did not invoke the credential provider.

--- a/examples/kubernetes/README.md
+++ b/examples/kubernetes/README.md
@@ -2,6 +2,30 @@
 
 These examples show the resources kubelet needs to pull Harbor images with `credential-provider-harbor` and service account tokens.
 
+## Harbor Setup
+
+Create a Harbor Federated IDP for your Kubernetes service account issuer. For a cluster issuer of `https://kind.128.140.12.238.nip.io`, use:
+
+```text
+OpenID configuration URL: https://kind.128.140.12.238.nip.io/.well-known/openid-configuration
+Issuer: https://kind.128.140.12.238.nip.io
+Audience: <your-harbor-audience>
+```
+
+Create a federated robot account with pull permission and claim rules such as:
+
+```text
+iss == <cluster-service-account-issuer>
+aud == <your-harbor-audience>
+sub == system:serviceaccount:<namespace>:<service-account>
+```
+
+For the default service account in the default namespace:
+
+```text
+sub == system:serviceaccount:default:default
+```
+
 ## kind
 
 For local kind clusters, make sure the kubelet process is actually started with the credential provider flags. Installing the binary and `CredentialProviderConfig` file is not enough.
@@ -52,3 +76,14 @@ kubectl apply -f examples/kubernetes/pod-example.yaml
 ```
 
 If the pod fails with `no basic auth credentials`, check the live kubelet command line first. That error usually means kubelet did not invoke the credential provider.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| [`k8s_credential_provider_config.yaml`](k8s_credential_provider_config.yaml) | Kubelet `CredentialProviderConfig` example. |
+| [`rbac-audience.yaml`](rbac-audience.yaml) | RBAC for kubelets to request service account tokens with the Harbor audience. |
+| [`pod-example.yaml`](pod-example.yaml) | Test pod that pulls from Harbor without `imagePullSecrets`. |
+| [`k3d-config.yaml`](k3d-config.yaml) | k3d cluster config example for mounting provider files. |
+| [`k3s-config.yaml`](k3s-config.yaml) | k3s config drop-in for credential-provider paths. |
+| [`kind-kubelet-systemd-dropin.conf`](kind-kubelet-systemd-dropin.conf) | Optional kind fallback when `KUBELET_EXTRA_ARGS` is not propagated. |

--- a/examples/kubernetes/kind-kubelet-systemd-dropin.conf
+++ b/examples/kubernetes/kind-kubelet-systemd-dropin.conf
@@ -1,0 +1,6 @@
+[Service]
+# Optional kind fallback. Use only when KUBELET_EXTRA_ARGS is present in systemd
+# but missing from the live kubelet command line.
+Environment="KUBELET_EXTRA_ARGS=--image-credential-provider-bin-dir=/var/lib/kubelet/credential-provider --image-credential-provider-config=/var/lib/kubelet/credential-provider-config.yaml"
+ExecStart=
+ExecStart=/usr/bin/kubelet $KUBELET_KUBECONFIG_ARGS $KUBELET_CONFIG_ARGS $KUBELET_KUBEADM_ARGS --image-credential-provider-bin-dir=/var/lib/kubelet/credential-provider --image-credential-provider-config=/var/lib/kubelet/credential-provider-config.yaml


### PR DESCRIPTION
## Summary
- Add an opt-in kind kubelet ExecStart override for cases where KUBELET_EXTRA_ARGS is not present in the live kubelet process.
- Expose the override through Helm as kubelet.forceExecStartOverride and document when to enable it.
- Add kind troubleshooting docs and tests for default behavior plus idempotent forced override writes.

## Verification
- go test ./...
- helm template credential-provider-harbor deploy/helm/credential-provider-harbor --set registry.host=harbor.example.com --set profile=kind
- helm template credential-provider-harbor deploy/helm/credential-provider-harbor --set registry.host=harbor.example.com --set profile=kind --set kubelet.forceExecStartOverride=true

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-in kubelet ExecStart override for `kind` clusters when `KUBELET_EXTRA_ARGS` isn’t picked up, exposed via Helm. Also switches CI/release to a configurable registry, publishes the Helm chart as OCI, uploads installer binaries, and adds example READMEs (GitHub Actions, GitLab CI, Kubernetes).

- **Bug Fixes**
  - For `profile=kind`, added a systemd drop-in writer that resets `ExecStart` and appends `--image-credential-provider-{bin-dir,config}`; default still uses `KUBELET_EXTRA_ARGS`.
  - Helm exposes `kubelet.forceExecStartOverride` (plumbed to `FORCE_KUBELET_EXECSTART`) and the DaemonSet passes it through.
  - Added kind troubleshooting docs, an example drop-in, and tests for default behavior and idempotent override writes.

- **New Features**
  - CI/release now use `REGISTRY_ADDRESS`/`PROJECT_NAME`/`REGISTRY_USERNAME`, push the chart as OCI, upload installer binaries, and add `task helm-push`.
  - Added example READMEs; default chart `image.repository` is `8gears.container-registry.com/8gcr/credential-provider-harbor-deployer`.

- **Migration**
  - Only for `kind` if pulls fail and kubelet is missing the provider flags: re-run Helm with `--set kubelet.forceExecStartOverride=true`. Verify flags are present on the live kubelet command line.

<sup>Written for commit 3c68093135b481a681595b31ea62ee8b0d6d9fe6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

