### PR TITLE
fix: Align Helm app version with deployer tag

### DIFF
--- a/deploy/helm/credential-provider-harbor/Chart.yaml
+++ b/deploy/helm/credential-provider-harbor/Chart.yaml
@@ -3,7 +3,7 @@ name: credential-provider-harbor
 description: Deploy the credential-provider-harbor binary to Kubernetes nodes for Harbor Workload Identity Federation
 type: application
 version: 0.1.0
-appVersion: "0.1.0"
+appVersion: "v0.0.1"
 keywords:
   - harbor
   - credential-provider


### PR DESCRIPTION
## Summary
- Aligns the Helm chart appVersion with the published `v0.0.1` deployer image tag.
- Keeps `image.tag` override behavior unchanged while fixing the default rendered image reference.

Closes #5

## Testing
- `helm lint deploy/helm/credential-provider-harbor --set registry.host=harbor.local`
- `helm template foo deploy/helm/credential-provider-harbor --set profile=k3s --set registry.host=harbor.local`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set Helm chart `appVersion` to `v0.0.1` to match the published deployer image tag so the default rendered image uses the correct tag. `image.tag` override continues to work the same.

<sup>Written for commit 346982bc202a4e2c64cbd52c4a87507e62256826. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

