### PR TITLE
fix: Use SemVer app version in Helm chart

### DIFF
--- a/deploy/helm/credential-provider-harbor/Chart.yaml
+++ b/deploy/helm/credential-provider-harbor/Chart.yaml
@@ -3,7 +3,7 @@ name: credential-provider-harbor
 description: Deploy the credential-provider-harbor binary to Kubernetes nodes for Harbor Workload Identity Federation
 type: application
 version: 0.1.0
-appVersion: "v0.0.1"
+appVersion: "0.0.1"
 keywords:
   - harbor
   - credential-provider


### PR DESCRIPTION
## Summary
- Sets Helm `appVersion` to `0.0.1` for SemVer-style application metadata.
- Keeps `image.tag` empty so the chart follows the existing Helm pattern of defaulting the image tag to `Chart.appVersion`.

## Testing
- `helm lint deploy/helm/credential-provider-harbor --set registry.host=harbor.local`
- `helm template foo deploy/helm/credential-provider-harbor --set profile=k3s --set registry.host=harbor.local`

Signed-off-by: Prasanth Baskar <bupdprasanth@gmail.com>